### PR TITLE
Remove dependency on Arquillian-BOM pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,13 +120,6 @@
          <version>1.6.2</version>
       </dependency>
       <dependency>
-         <groupId>org.jboss.arquillian</groupId>
-         <artifactId>arquillian-bom</artifactId>
-         <version>1.1.2.Final</version>
-         <scope>test</scope>
-         <type>pom</type>
-      </dependency>
-      <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
          <version>1.0.0.Final</version>


### PR DESCRIPTION
Arquillian-BOM should only be imported via DependencyManagement,
and not as a direct Dependency.

The idea is to define the versions of Arquillian-Core to use, not to import them all.
The import of these dependencies happens via the artifacts arquillian-junit-container
and the container adapter. 
